### PR TITLE
Buffer enqueue, 2nd fix.

### DIFF
--- a/Alc/backends/opensl.c
+++ b/Alc/backends/opensl.c
@@ -388,6 +388,19 @@ static void opensl_stop_playback(ALCdevice *Device)
         PRINTERR(result, "bufferQueue->Clear");
     }
 
+	// wait for sound to stop playing so no more callback triggered.
+	SLAndroidSimpleBufferQueueState state;
+	result = VCALL(bufferQueue, GetState)(&state);
+	PRINTERR(result, "bufferQueue->GetState");
+	while (state.count > 0 && result == SL_RESULT_SUCCESS)
+	{
+		result = VCALL0(bufferQueue, Clear)();
+		PRINTERR(result, "bufferQueue->Clear (while loop)");
+
+		result = VCALL(bufferQueue, GetState)(&state);
+		PRINTERR(result, "bufferQueue->GetState (while loop)");
+	}
+
     free(data->buffer);
     data->buffer = NULL;
     data->bufferSize = 0;


### PR DESCRIPTION
**The initial pull request still had a bug in it, is fixed now. **

Certain Android devices were crashing with an "invalid device" error when the app is minimized (paused) and them resumed again. It turns out this was caused by incorrect buffer enqueueing in the opensl.c file.

Because the error appears only on certain devices it looks as a opensl implementation issue.

The issue was that the 'opensl_callback' function (which is called whenever a buffer finishes playing) would sometimes get called even after the player state is set to SL_PLAYSTATE_STOPPED, this is because the callback is called from a different thread and does not seem to be synchronized internally.
(there were quite a few people on the web complaining about this).

So to fix this 2 things are needed:

1) When the player is stopped we must poll the number of enqueued buffers and wait until this number reaches 0 because a buffer end callback may still be triggered from the callback thread after stopping the play. 
Now since the buffer playing is stopped, sometimes a buffer will still be in the queue and since it's stopped it won't ever get cleared. That is why we need to call to 'Clear' on the buffer queue also.

2) For some strange reason when we resume the app a buffer will sometimes magically appear in the buffer queue even though the fix 1) clears it.
It is as if the callback gets called again even though the player is stopped and we cleared all buffers in 1). That is why we need to clear the buffer queue before enqueueing buffers again when we start the player.

This was tested on many device on AWS Device farm so it should be good.

Also replaced manual buffer index tracking with internal openSL state tracking in the callback.

